### PR TITLE
feat: show creator and poc in members page

### DIFF
--- a/modules/teams/components/team-members.tsx
+++ b/modules/teams/components/team-members.tsx
@@ -29,6 +29,22 @@ const QUERY_PARAMS_KEYS = {
   search: 'search',
 }
 
+const PocLabel = () => {
+  return (
+    <div className="rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-700">
+      POC
+    </div>
+  )
+}
+
+const CreatorLabel = () => {
+  return (
+    <div className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700">
+      Creator
+    </div>
+  )
+}
+
 type TeamMembersProps = {
   teamId: string
 }
@@ -110,6 +126,8 @@ export const TeamMembers = ({ teamId }: TeamMembersProps) => {
                           <AvatarFallback className="font-medium">{member.name[0]}</AvatarFallback>
                         </Avatar>
                         <span>{member.name}</span>
+                        {member.id === data?.created_by && <CreatorLabel />}
+                        {member.id === data?.poc_id && <PocLabel />}
                       </div>
                     </TableCell>
 


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 19 July 2025
<!--Developer Name Here-->
Developer Name: Yash Raj

---

## Issue Ticket Number
- N/A

## Description
- show creator and poc label in members page

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<img width="1332" height="771" alt="image" src="https://github.com/user-attachments/assets/a853e09a-8968-4538-a83e-de02b862021b" />

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add visual labels to indicate the 'Creator' and 'Point of Contact (POC)' for team members on the team members page.

### Why are these changes being made?

The change enhances user experience by clearly displaying the roles of team members directly on the interface, making it easy for users to identify key contacts such as the Creator and POC within the team. This approach improves clarity and navigability within the team management interface.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->