### PR TITLE
fix invalidation when creating / editing a todo

### DIFF
--- a/api/tasks/tasks.api.ts
+++ b/api/tasks/tasks.api.ts
@@ -32,8 +32,9 @@ export const TasksApi = {
 
   updateTask: {
     key: ['tasksApi.updateTask'],
-    fn: async ({ id, ...task }: UpdateTaskDto): Promise<void> => {
-      await apiClient.patch<TTask>(`/v1/tasks/${id}/update`, task)
+    fn: async ({ id, ...task }: UpdateTaskDto): Promise<TTask> => {
+      const { data } = await apiClient.patch<TTask>(`/v1/tasks/${id}/update`, task)
+      return data
     },
   },
 

--- a/components/edit-task-button.tsx
+++ b/components/edit-task-button.tsx
@@ -1,3 +1,4 @@
+import { USER_TYPE_ENUM } from '@/api/common/common-enum'
 import { TasksApi } from '@/api/tasks/tasks.api'
 import { TTask } from '@/api/tasks/tasks.types'
 import { TodoUtil } from '@/lib/todo-util'
@@ -21,8 +22,14 @@ export const EditTodoButton = ({ todo }: EditTodoButtonProps) => {
 
   const updateTaskMutation = useMutation({
     mutationFn: TasksApi.updateTask.fn,
-    onSuccess: () => {
+    onSuccess: (res) => {
       void queryClient.invalidateQueries({ queryKey: TasksApi.getTasks.key() })
+
+      if (res.assignee?.user_type === USER_TYPE_ENUM.TEAM) {
+        void queryClient.invalidateQueries({
+          queryKey: TasksApi.getTasks.key(res.assignee.assignee_id),
+        })
+      }
       toast.success('Todo updated successfully')
       setShowEditTaskForm(false)
     },

--- a/components/reassign-user.tsx
+++ b/components/reassign-user.tsx
@@ -41,6 +41,7 @@ const ReassignUserModal = ({
     onSuccess: () => {
       toast.success(`Task assigned to ${selectedUser?.name}`)
       void queryClient.invalidateQueries({ queryKey: TasksApi.getTasks.key(teamId) })
+      void queryClient.invalidateQueries({ queryKey: TasksApi.getTasks.key() })
       onOpenChange(false)
       setSelectedUser(null)
     },
@@ -52,7 +53,6 @@ const ReassignUserModal = ({
   const handleReassign = () => {
     if (!selectedUser) return
 
-    debugger
     reassignTaskMutation.mutate({
       task_id: taskId,
       executor_id: selectedUser.id,

--- a/modules/dashboard/components/create-todo-button.tsx
+++ b/modules/dashboard/components/create-todo-button.tsx
@@ -1,3 +1,4 @@
+import { USER_TYPE_ENUM } from '@/api/common/common-enum'
 import { TasksApi } from '@/api/tasks/tasks.api'
 import { CreateEditTodoDialog } from '@/components/create-edit-todo-dialog'
 import { Button } from '@/components/ui/button'
@@ -12,9 +13,15 @@ export const CreateTodoButton = () => {
 
   const createTaskMutation = useMutation({
     mutationFn: TasksApi.createTask.fn,
-    onSuccess: () => {
+    onSuccess: (res) => {
       void queryClient.invalidateQueries({ queryKey: TasksApi.getTasks.key() })
-      void queryClient.invalidateQueries({ queryKey: TasksApi.getTasks.key() })
+
+      if (res.assignee?.user_type === USER_TYPE_ENUM.TEAM) {
+        void queryClient.invalidateQueries({
+          queryKey: TasksApi.getTasks.key(res.assignee.assignee_id),
+        })
+      }
+
       toast.success('Todo created successfully')
       setShowCreateTaskForm(false)
     },


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 19 July 2025
<!--Developer Name Here-->
Developer Name: Yash Raj

---

## Issue Ticket Number
- N/A

## Description
- fix tanstack query cache invalidation when creating / updating a todo.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify task creation and editing processes to correctly handle query invalidation, returning updated task data and ensuring relevant queries are invalidated based on assigned user type.

### Why are these changes being made?

The changes address a previous issue where updates returned no data and did not properly invalidate queries, causing stale data when tasks were updated or created, especially regarding tasks assigned to users of type `TEAM`. By returning data and conditionally invalidating queries based on user type, we ensure the application's data state is synchronized correctly.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->