### PR TITLE
fix(creat-edit-todo-form): add class to description textarea to prevent layout breaking

### DIFF
--- a/src/components/todos/create-edit-todo-dialog.tsx
+++ b/src/components/todos/create-edit-todo-dialog.tsx
@@ -48,13 +48,15 @@ export const CreateEditTodoDialog = ({
           </AlertDialogTitle>
         </AlertDialogHeader>
 
-        <CreateEditTodoForm
-          mode={mode}
-          onSubmit={onSubmit}
-          initialData={defaultData}
-          isSubmitting={isMutationPending}
-          onCancel={() => onOpenChange(false)}
-        />
+        <div className="min-w-0">
+          <CreateEditTodoForm
+            mode={mode}
+            onSubmit={onSubmit}
+            initialData={defaultData}
+            isSubmitting={isMutationPending}
+            onCancel={() => onOpenChange(false)}
+          />
+        </div>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/src/components/todos/create-edit-todo-dialog.tsx
+++ b/src/components/todos/create-edit-todo-dialog.tsx
@@ -48,15 +48,13 @@ export const CreateEditTodoDialog = ({
           </AlertDialogTitle>
         </AlertDialogHeader>
 
-        <div className="min-w-0">
-          <CreateEditTodoForm
-            mode={mode}
-            onSubmit={onSubmit}
-            initialData={defaultData}
-            isSubmitting={isMutationPending}
-            onCancel={() => onOpenChange(false)}
-          />
-        </div>
+        <CreateEditTodoForm
+          mode={mode}
+          onSubmit={onSubmit}
+          initialData={defaultData}
+          isSubmitting={isMutationPending}
+          onCancel={() => onOpenChange(false)}
+        />
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/src/components/todos/create-edit-todo-form.tsx
+++ b/src/components/todos/create-edit-todo-form.tsx
@@ -179,7 +179,7 @@ export const CreateEditTodoForm = ({
         <Textarea
           id="description"
           placeholder="e.g Nothing is cool in here"
-          className="max-h-32"
+          className="break-word max-h-32"
           {...register('description')}
         />
       </FormInput>

--- a/src/components/todos/create-edit-todo-form.tsx
+++ b/src/components/todos/create-edit-todo-form.tsx
@@ -179,6 +179,7 @@ export const CreateEditTodoForm = ({
         <Textarea
           id="description"
           placeholder="e.g Nothing is cool in here"
+          className="break-all"
           {...register('description')}
         />
       </FormInput>

--- a/src/components/todos/create-edit-todo-form.tsx
+++ b/src/components/todos/create-edit-todo-form.tsx
@@ -179,7 +179,7 @@ export const CreateEditTodoForm = ({
         <Textarea
           id="description"
           placeholder="e.g Nothing is cool in here"
-          className="max-h-32 break-all"
+          className="max-h-32"
           {...register('description')}
         />
       </FormInput>

--- a/src/components/todos/create-edit-todo-form.tsx
+++ b/src/components/todos/create-edit-todo-form.tsx
@@ -179,7 +179,7 @@ export const CreateEditTodoForm = ({
         <Textarea
           id="description"
           placeholder="e.g Nothing is cool in here"
-          className="break-all"
+          className="max-h-32 break-all"
           {...register('description')}
         />
       </FormInput>

--- a/src/index.css
+++ b/src/index.css
@@ -61,6 +61,10 @@
   }
 }
 
+@utility break-word {
+  word-break: break-word;
+}
+
 @utility no-scrollbar {
   /* Hide scrollbar for Chrome, Safari, and Opera */
   &::-webkit-scrollbar {


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 14 Sep 2025
<!--Developer Name Here-->
Developer Name: @Hariom01010 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
Closes #207 
## Description
This PR fixes the layout-breaking issue in the description textarea of the create/edit todo form.
A new class was added to ensure the textarea displays correctly when long text is copy pasted into it

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [X] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [X] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [X] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [X] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [X] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
## Before:
<img width="1919" height="958" alt="image" src="https://github.com/user-attachments/assets/9e5343e3-97d5-47e5-8580-e419e570f3c3" />

## After:
<img width="1919" height="965" alt="image" src="https://github.com/user-attachments/assets/e74989a2-dff7-464d-9aa9-d274ea25526f" />

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add className="break-all" to the description textarea in CreateEditTodoForm to prevent layout breakage when long text is entered.

### Why are these changes being made?

Long descriptions can overflow or disrupt layout; applying break-all ensures text wraps within the textarea and preserves the form layout.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->