### PR TITLE
fix(#200): show createdBy on edit modal and remove from table

### DIFF
--- a/src/components/todos/create-edit-todo-form.tsx
+++ b/src/components/todos/create-edit-todo-form.tsx
@@ -16,7 +16,7 @@ import { cn, isPastDate } from '@/lib/utils'
 import { SelectLabels } from '@/modules/dashboard/components/select-labels'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useQuery } from '@tanstack/react-query'
-import { CalendarIcon, CircleDotIcon, LucideIcon, PlayIcon, TagIcon } from 'lucide-react'
+import { CalendarIcon, CircleDotIcon, LucideIcon, PlayIcon, TagIcon, UserIcon } from 'lucide-react'
 import { useState } from 'react'
 import { Controller, useForm, UseFormWatch } from 'react-hook-form'
 import { z } from 'zod'
@@ -40,6 +40,12 @@ const todoFormSchema = z.object({
     },
     { error: 'Assignee is required' },
   ),
+  createdBy: z
+    .object({
+      label: z.string(),
+      value: z.string(),
+    })
+    .optional(),
 })
 
 export type TTodoFormData = z.infer<typeof todoFormSchema>
@@ -134,6 +140,7 @@ export const CreateEditTodoForm = ({
       status: initialData?.status || TASK_STATUS_ENUM.TODO,
       labels: initialData?.labels || [],
       assignee: initialData?.assignee || undefined,
+      createdBy: initialData?.createdBy || undefined,
     },
   })
 
@@ -327,6 +334,28 @@ export const CreateEditTodoForm = ({
               </FormInput>
             )}
           />
+
+          {mode === 'edit' && (
+            <Controller
+              control={control}
+              name="createdBy"
+              render={({ field }) => (
+                <FormInput
+                  label="Created By"
+                  htmlFor="createdBy"
+                  icon={UserIcon}
+                  errorMessage={errors.createdBy?.message}
+                >
+                  <Input
+                    {...field}
+                    value={field.value?.label ?? '--'}
+                    readOnly
+                    className="cursor-default border-0 text-gray-700 shadow-none focus:ring-0 focus:outline-none focus-visible:ring-0"
+                  />
+                </FormInput>
+              )}
+            />
+          )}
         </div>
       </div>
 

--- a/src/components/todos/todo-list-table.tsx
+++ b/src/components/todos/todo-list-table.tsx
@@ -34,7 +34,6 @@ export const TodoListTableHeader = ({
         <TableHead className="text-black">Label</TableHead>
         <TableHead className="text-black">Priority</TableHead>
         <TableHead className="text-black">Assignee</TableHead>
-        <TableHead className="text-black">Created By</TableHead>
         <TableHead className="text-black">Due Date</TableHead>
         {showDeferredColumn && <TableHead className="text-black">Deferred Until</TableHead>}
         {showActions && <TableHead className="text-black">Actions</TableHead>}
@@ -74,8 +73,6 @@ const TodoListTableRow = ({
       </TableCell>
 
       <TableCell className="whitespace-nowrap">{todo.assignee?.assignee_name ?? '--'}</TableCell>
-
-      <TableCell className="whitespace-nowrap">{todo.createdBy?.name ?? '--'}</TableCell>
 
       <TableCell className="whitespace-nowrap">
         {todo.dueAt ? new DateUtil(todo.dueAt).format(DateFormats.D_MMM_YYYY) : '--'}

--- a/src/lib/todo-util.ts
+++ b/src/lib/todo-util.ts
@@ -62,6 +62,12 @@ export class TodoUtil {
             type: todo.assignee.user_type,
           }
         : undefined,
+      createdBy: todo.createdBy
+        ? {
+            label: todo.createdBy.name,
+            value: todo.createdBy.id,
+          }
+        : undefined,
     }
   }
 }

--- a/src/modules/teams/team-tasks.tsx
+++ b/src/modules/teams/team-tasks.tsx
@@ -48,8 +48,6 @@ const TodoListTableRow = ({ todo, team }: TodoListTableRowProps) => {
 
       <TableCell className="whitespace-nowrap">{todo.assignee?.assignee_name ?? '--'}</TableCell>
 
-      <TableCell className="whitespace-nowrap">{todo.createdBy?.name ?? '--'}</TableCell>
-
       <TableCell className="whitespace-nowrap">
         {todo.dueAt ? new DateUtil(todo.dueAt).format(DateFormats.D_MMM_YYYY) : '--'}
       </TableCell>


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 30-09-2025
<!--Developer Name Here-->
Developer Name: @MayankBansal12 

---

## Issue Ticket Number
- closes #200 

## Description
- Adds createdBy in edit todo modal
- Removes column for created by from the table

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>working proof</summary>


https://github.com/user-attachments/assets/740bf7b5-ad70-4d03-9ec6-413bde6a0c59



</details>

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Show the Created By value in the edit modal and remove the Created By column from the todo list table; wire Created By through the TodoUtil mapping so the field is available in the edit form.

### Why are these changes being made?

To display who created each todo in the edit view without cluttering the list UI; Created By remains in the data layer for consistency and future use.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->