### PR TITLE
Dev to Main Sync

### DIFF
--- a/src/api/teams/teams.type.ts
+++ b/src/api/teams/teams.type.ts
@@ -55,6 +55,7 @@ export enum TeamActivityActions {
   MEMBER_ADDED_TO_TEAM = 'member_added_to_team',
   MEMBER_REMOVED_FROM_TEAM = 'member_removed_from_team',
   MEMBER_LEFT_TEAM = 'member_left_team',
+  POC_CHANGED = 'poc_changed',
 }
 
 export type BaseActivity = {
@@ -115,6 +116,11 @@ export type MemberLeftTeamActivity = BaseActivity & {
   performed_by_name: string
 }
 
+export type PocChangedActivity = BaseActivity & {
+  action: TeamActivityActions.POC_CHANGED
+  performed_by_name: string
+}
+
 export type TeamActivity =
   | TeamCreationActivity
   | TaskAssignActivity
@@ -125,6 +131,7 @@ export type TeamActivity =
   | MemberJoinActivity
   | RemoveTeamMemberActivity
   | MemberLeftTeamActivity
+  | PocChangedActivity
 
 export type TeamActivityTimeline = {
   timeline: TeamActivity[]

--- a/src/components/teams/team-members.tsx
+++ b/src/components/teams/team-members.tsx
@@ -115,6 +115,9 @@ export const TeamMembers = ({ teamId }: TeamMembersProps) => {
       queryClient.invalidateQueries({
         queryKey: TasksApi.getTasks.key(),
       })
+      queryClient.invalidateQueries({
+        queryKey: TeamsApi.getTeamActivities.key({ teamId }),
+      })
       toast.success('POC updated successfully')
     },
     onError: () => {

--- a/src/lib/team-utils.ts
+++ b/src/lib/team-utils.ts
@@ -89,6 +89,14 @@ export function getActivityUIData(activity: TeamActivity): ActivityUIData | unde
         description: `${activity.performed_by_name} left the team ${activity.team_name}`,
         date,
       }
+
+    case TeamActivityActions.POC_CHANGED:
+      return {
+        icon: UsersRound,
+        title: 'Point of Contact changed',
+        description: `${activity.performed_by_name} changed the POC of the team ${activity.team_name}`,
+        date,
+      }
     default:
       return undefined
   }


### PR DESCRIPTION
Date: 21 Oct 2025

Developer Name: @AnujChhikara 


## Issue Resolved

- PoC changed activity not showing in the team activity section

### PRs going in Sync
- #218

## Description
- Added the poc_change activity in the team activity section

### Documentation Updated?

- [ ] Yes
- [x] No


### Under Feature Flag

- [ ] Yes
- [x] No

### Database Changes

- [ ] Yes
- [x] No

### Breaking Changes

- [ ] Yes
- [x] No


### Development Tested?

- [x] Yes
- [ ] No


## Screenshots
<details>
<summary>Staging Proof</summary>


https://github.com/user-attachments/assets/df9e4d06-03d3-4db6-a555-59997be05ba6


</details>

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add support for Point of Contact (POC) change activity across the codebase: extend activity types, UI rendering, and cache invalidation.

### Why are these changes being made?
To surface POC changes in the team activity timeline and ensure the UI stays up-to-date after a POC update. This introduces a new activity type, corresponding UI data, and cache invalidation for the team activities feed.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->